### PR TITLE
Compatibility with node 0.10.x

### DIFF
--- a/src/nodePortAudio.cpp
+++ b/src/nodePortAudio.cpp
@@ -349,7 +349,7 @@ static int nodePortAudioCallback(
     if(data->readIdx == data->writeIdx) {
       uv_work_t* req = new uv_work_t();
       req->data = data;
-      uv_queue_work(uv_default_loop(), req, EIO_EmitUnderrun, EIO_EmitUnderrunAfter);
+      uv_queue_work(uv_default_loop(), req, EIO_EmitUnderrun, (uv_after_work_cb) EIO_EmitUnderrunAfter);
       return paContinue;
     }
     *out++ = data->buffer[data->readIdx++];

--- a/src/nodePortAudio.h
+++ b/src/nodePortAudio.h
@@ -2,6 +2,7 @@
 #include <node.h>
 #include <v8.h>
 #include <node_buffer.h>
+#include <cstring>
 
 v8::Handle<v8::Value> Open(const v8::Arguments& args);
 v8::Handle<v8::Value> GetDevices(const v8::Arguments& args);


### PR DESCRIPTION
Fixes #4
Pull Request for Issue https://github.com/joeferner/node-portaudio/issues/4

Compatibility with Node.js 0.10.x (stable version)

added explicit cast and missing dependency library with cstring

Tested in Ubuntu 13.04 with Node.js 0.10.15
